### PR TITLE
Update creem to 0.2.1 and switch source to npm

### DIFF
--- a/Formula/creem.rb
+++ b/Formula/creem.rb
@@ -4,8 +4,9 @@
 class Creem < Formula
   desc "Command-line interface for Creem"
   homepage "https://creem.io"
-  url "https://github.com/armitage-labs/creem-cli/releases/download/v0.2.0/creem-cli-0.2.0.tgz"
-  sha256 "1851e47ebc93b0b7ca91b8351932ad91fa112a62c5a1926466815a6befafb23c"
+  url "https://registry.npmjs.org/@creem_io/cli/-/cli-0.2.1.tgz"
+  version "0.2.1"
+  sha256 "bdeca29f8a5a9eacaabf54b2ea6774a7e8b8f5f8453ea532322780955b14215b"
   license "MIT"
 
   depends_on "node@22"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homebrew Tap for CREEM CLI
 
-Official Homebrew tap for [CREEM CLI](https://github.com/armitage-labs/pugpay-monorepo/tree/main/packages/creem-cli).
+Official Homebrew tap for [CREEM CLI](https://github.com/armitage-labs/creem/tree/main/packages/cli).
 
 ## Installation
 
@@ -45,12 +45,12 @@ brew untap armitage-labs/creem
 
 ### npm (Global)
 ```bash
-npm install -g creem-cli
+npm install -g @creem_io/cli
 ```
 
 ### npx (No Install)
 ```bash
-npx creem-cli <command>
+npx @creem_io/cli <command>
 ```
 
 ## Links


### PR DESCRIPTION
- Repoint formula at the npm registry tarball for @creem_io/cli (the CLI moved into the armitage-labs/creem monorepo and was republished under the @creem_io scope; the old creem-cli npm package was unpublished)
- Bump 0.2.0 -> 0.2.1
- Fix stale README links (pugpay-monorepo -> creem, creem-cli -> @creem_io/cli)